### PR TITLE
Fix[CVE-2019-17495][CWE-352]:Swagger UI @import 跨站脚本漏洞

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -48,6 +48,11 @@
     <dependencyManagement>
         <dependencies>
             <dependency>
+                <groupId>io.springfox</groupId>
+                <artifactId>springfox-swagger-ui</artifactId>
+                <version>2.10.0</version>
+            </dependency>
+            <dependency>
                 <groupId>org.jboss.resteasy</groupId>
                 <artifactId>resteasy-core</artifactId>
                 <version>4.1.0</version>


### PR DESCRIPTION
升级io.springfox:springfox-swagger-ui到2.10.0