### PR TITLE
Fix[CVE-2020-1695][NVD-CWE-Other]:Red Hat Resteasy输入验证错误漏洞

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -50,7 +50,7 @@
             <dependency>
                 <groupId>org.jboss.resteasy</groupId>
                 <artifactId>resteasy-core</artifactId>
-                <version>4.1.0</version>
+                <version>4.1.1.Final</version>
             </dependency>
         </dependencies>
     </dependencyManagement>


### PR DESCRIPTION
升级org.jboss.resteasy:resteasy-core到4.1.1.Final