### PR TITLE
Fix[CVE-2022-32532][CWE-863]:Apache Shiro 权限绕过漏洞

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -48,6 +48,11 @@
     <dependencyManagement>
         <dependencies>
             <dependency>
+                <groupId>org.apache.shiro</groupId>
+                <artifactId>shiro-spring</artifactId>
+                <version>1.9.1</version>
+            </dependency>
+            <dependency>
                 <groupId>org.jboss.resteasy</groupId>
                 <artifactId>resteasy-core</artifactId>
                 <version>4.1.0</version>


### PR DESCRIPTION
升级org.apache.shiro:shiro-spring到1.9.1