### PR TITLE
Fix[CVE-2021-20293][CWE-79]:Red Hat Resteasy 跨站脚本漏洞

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -50,7 +50,7 @@
             <dependency>
                 <groupId>org.jboss.resteasy</groupId>
                 <artifactId>resteasy-core</artifactId>
-                <version>4.1.0</version>
+                <version>4.6.0.Final</version>
             </dependency>
         </dependencies>
     </dependencyManagement>


### PR DESCRIPTION
升级org.jboss.resteasy:resteasy-core到4.6.0.Final